### PR TITLE
add number of reversions option

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,19 @@
 'use strict';
 var through = require('through2');
 
-module.exports = function () {
+module.exports = function (reversions) {
+	reversions = typeof reversions === 'number' ? reversions : 1;
+
 	return through.obj(function (file, enc, cb) {
 		var history = file.history;
+		var highestIndex = history.length - 1;
 
-		if (history.length > 1) {
-			history.pop();
-			file.path = history[history.length - 1];
+		if (reversions > highestIndex) {
+			reversions = highestIndex;
 		}
+
+		history.splice(-reversions, reversions);
+		file.path = history[history.length - 1];
 
 		cb(null, file);
 	});

--- a/readme.md
+++ b/readme.md
@@ -18,11 +18,20 @@ $ npm install --save-dev gulp-revert-path
 var gulp = require('gulp');
 var babel = require('gulp-babel');
 var revertPath = require('gulp-revert-path');
+var rename = require('gulp-rename');
 
 gulp.task('default', function () {
 	return gulp.src('src/app.jsx')
 		.pipe(babel())       // file.path => src/app.js
 		.pipe(revertPath())  // file.path => src/app.jsx
+		.pipe(gulp.dest('dist'));
+});
+
+gulp.task('es2015', function () {
+	return gulp.src('src/app.txt')
+		.pipe(rename('src/app.jsx'))  // file.path => src/app.jsx
+		.pipe(babel())                // file.path => src/app.js
+		.pipe(revertPath(2))          // file.path => src/app.txt
 		.pipe(gulp.dest('dist'));
 });
 ```

--- a/test.js
+++ b/test.js
@@ -10,12 +10,14 @@ it('reverts the path to the previous one', function (done) {
 		assert.strictEqual(path.extname(file.path), '.foo');
 		file.path = gutil.replaceExtension(file.path, '.bar');
 		assert.strictEqual(path.extname(file.path), '.bar');
+		assert.strictEqual(file.history.length, 2);
 		cb(null, file);
 	});
 
 	s.pipe(revertPath()).pipe(through.obj(function (file, enc, cb) {
 		assert.strictEqual(path.extname(file.path), '.foo');
 		assert.strictEqual(path.extname(file.history[0]), '.foo');
+		assert.strictEqual(file.history.length, 1);
 		cb();
 	}));
 
@@ -38,12 +40,14 @@ it('reverts the path to the previous two', function (done) {
 		assert.strictEqual(path.extname(file.path), '.bar');
 		file.path = gutil.replaceExtension(file.path, '.baz');
 		assert.strictEqual(path.extname(file.path), '.baz');
+		assert.strictEqual(file.history.length, 3);
 		cb(null, file);
 	});
 
 	s.pipe(revertPath(2)).pipe(through.obj(function (file, enc, cb) {
 		assert.strictEqual(path.extname(file.path), '.foo');
 		assert.strictEqual(path.extname(file.history[0]), '.foo');
+		assert.strictEqual(file.history.length, 1);
 		cb();
 	}));
 
@@ -63,12 +67,14 @@ it('successfully processes files with unmodified paths', function (done) {
 	var s = through.obj(function (file, enc, cb) {
 		assert.strictEqual(path.extname(file.path), '.foo');
 		assert.deepEqual(path.extname(file.history[0]), '.foo');
+		assert.strictEqual(file.history.length, 1);
 		cb(null, file);
 	});
 
 	s.pipe(revertPath()).pipe(through.obj(function (file, enc, cb) {
 		assert.strictEqual(path.extname(file.path), '.foo');
 		assert.deepEqual(path.extname(file.history[0]), '.foo');
+		assert.strictEqual(file.history.length, 1);
 		cb();
 	}));
 
@@ -91,12 +97,14 @@ it('reverts as much as possible', function (done) {
 		assert.strictEqual(path.extname(file.path), '.bar');
 		file.path = gutil.replaceExtension(file.path, '.baz');
 		assert.strictEqual(path.extname(file.path), '.baz');
+		assert.strictEqual(file.history.length, 3);
 		cb(null, file);
 	});
 
 	s.pipe(revertPath(100)).pipe(through.obj(function (file, enc, cb) {
 		assert.strictEqual(path.extname(file.path), '.foo');
 		assert.deepEqual(path.extname(file.history[0]), '.foo');
+		assert.strictEqual(file.history.length, 1);
 		cb();
 	}));
 


### PR DESCRIPTION
Ref: https://github.com/sindresorhus/vinyl-paths/issues/2
Only thing is its probably not the best use-case to demonstrate in the README.md. However I can't use double `dest` because the `base` would change in after the first `dest()`. https://github.com/wearefractal/vinyl-fs/pull/77
